### PR TITLE
Fix unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 language: python
+
+sudo: false
+
 python:
   - "2.7"
 
-addons:
-  apt:
-    packages:
-    - libudunits2-0
-    - netcdf-bin
+before_install:
+  - wget http://bit.ly/miniconda -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+  - conda update conda
+  - conda config --add channels conda-forge --force
+  - conda create --name TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+  - source activate TEST
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      conda install --yes httpretty ;
+    fi
 
 script:
 - python setup.py test -s cc_plugin_imos.tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     packages:
     - libudunits2-0
+    - netcdf-bin
 
 script:
 - python setup.py test -s cc_plugin_imos.tests

--- a/cc_plugin_imos/imos.py
+++ b/cc_plugin_imos/imos.py
@@ -526,6 +526,7 @@ class IMOSBaseCheck(BaseNCCheck):
             ret_val.append(result)
 
             result_name = ('var', var.name, 'check_monotonic')
+            var.set_auto_mask(False)  # don't mask out any fill/invalid values (there shouldn't be any!)
             passed = is_monotonic(var.__array__())
             reasoning = None
 

--- a/cc_plugin_imos/tests/data/imos_bad_data.cdl
+++ b/cc_plugin_imos/tests/data/imos_bad_data.cdl
@@ -17,15 +17,11 @@ variables:
 	int LATITUDE ;
 		LATITUDE:standard_name = "" ;
 		LATITUDE:axis = "" ;
-		LATITUDE:valid_max = "" ;
-		LATITUDE:valid_min = "" ;
 		LATITUDE:units = "" ;
 	int LONGITUDE ;
 		LONGITUDE:standard_name = "" ;
 		LONGITUDE:axis = "" ;
 		LONGITUDE:reference_datum = 123L ;
-		LONGITUDE:valid_min = "" ;
-		LONGITUDE:valid_max = "" ;
 		LONGITUDE:units = "" ;
 	double ticks(ticks) ;
 		ticks:standard_name = "" ;


### PR DESCRIPTION
Two minor fixes that will allow the unittests to pass with the latest version of the python netCDF4 package.
