### PR TITLE
Disable masking of variable values outside valid_min/max range

### DIFF
--- a/cc_plugin_imos/tests/data/imos_global_min_max.cdl
+++ b/cc_plugin_imos/tests/data/imos_global_min_max.cdl
@@ -1,0 +1,48 @@
+netcdf imos_global_min_max {
+dimensions:
+	TIME = 11 ;
+variables:
+	double TIME(TIME) ;
+		TIME:standard_name = "time" ;
+		TIME:long_name = "time" ;
+		TIME:units = "days since 1950-01-01 00:00:00 UTC" ;
+		TIME:calendar = "gregorian" ;
+		TIME:axis = "T" ;
+		TIME:valid_min = 0. ;
+		TIME:valid_max = 90000. ;
+	double LATITUDE(TIME) ;
+		LATITUDE:standard_name = "latitude" ;
+		LATITUDE:long_name = "latitude" ;
+		LATITUDE:units = "degrees_north" ;
+		LATITUDE:axis = "Y" ;
+		LATITUDE:reference_datum = "WGS84 coordinate reference system" ;
+		LATITUDE:valid_min = -90. ;
+		LATITUDE:valid_max = 90. ;
+	double LONGITUDE(TIME) ;
+		LONGITUDE:standard_name = "longitude" ;
+		LONGITUDE:long_name = "longitude" ;
+		LONGITUDE:units = "degrees_east" ;
+		LONGITUDE:axis = "X" ;
+		LONGITUDE:reference_datum = "WGS84 coordinate reference system" ;
+		LONGITUDE:valid_min = -180. ;
+		LONGITUDE:valid_max = 180. ;
+
+// global attributes:
+		:geospatial_lat_min = -30.0 ;
+		:geospatial_lat_max = 200.1 ;
+		:geospatial_lat_units = "degrees_north" ;
+		:geospatial_lon_min =  14.0 ;
+		:geospatial_lon_max = 113.94 ;
+		:geospatial_lon_units = "degrees_east" ;
+data:
+
+ LATITUDE =  200.1, -30.00, -21.86, -21.86, -21.86, -21.86,
+            -21.86, -21.86, -21.86, -21.86, -21.86 ;
+
+ LONGITUDE = 2200.0,  14.00, 100.00, 113.94, 113.94, 113.94,
+             113.94, 113.94, 113.94, 113.94, 113.94 ;
+
+ TIME = 22230.7, 22232.5, 22234.2, 22236.0, 22237.7, 22239.5,
+        22241.2, 22243.0, 22244.7, 22246.5, 22248.2 ;
+
+}

--- a/cc_plugin_imos/tests/data/imos_new_data.cdl
+++ b/cc_plugin_imos/tests/data/imos_new_data.cdl
@@ -69,10 +69,10 @@ variables:
 	double TIME(TIME) ;
 		TIME:standard_name = "time" ;
 		TIME:long_name = "time" ;
-		TIME:units = "hours since 1970-01-01 00:00:00 UTC" ;
+		TIME:units = "days since 1950-01-01 00:00:00 UTC" ;
 		TIME:calendar = "gregorian" ;
 		TIME:axis = "T" ;
-		TIME:valid_min = 0. ;
+		TIME:valid_min = 10000. ;
 		TIME:valid_max = 90000. ;
 	int TIMESERIES ;
 		TIMESERIES:long_name = "unique_identifier_for_each_timeseries_feature_instance_in_this_file" ;
@@ -115,14 +115,14 @@ variables:
 		:instrument_nominal_height = 39. ;
 		:instrument_nominal_depth = 16. ;
 		:site_depth_at_deployment = 55. ;
-		:geospatial_vertical_min = 16.f ;
-		:geospatial_vertical_max = 16.f ;
+		:geospatial_vertical_min = -22.222f ;
+		:geospatial_vertical_max = 23.1483f ;
 		:geospatial_vertical_positive = "down" ;
 		:time_deployment_start = "2010-11-11T05:58:00Z" ;
 		:time_deployment_start_origin = "TimeFirstInPos" ;
 		:time_deployment_end = "2011-04-29T04:31:00Z" ;
 		:time_deployment_end_origin = "TimeLastInPos" ;
-		:time_coverage_start = "2010-11-11T00:00:00Z" ;
+		:time_coverage_start = "1950-01-01T00:00:00Z" ;
 		:time_coverage_end = "2011-04-28T08:00:00Z" ;
 		:local_time_zone = 8.0 ;
 		:data_centre = "Australian Ocean Data Network (AODN)" ;
@@ -142,7 +142,7 @@ variables:
 		:history = "2016-07-18T01:04:44Z - depthPP: Depth computed from the 2 nearest pressure sensors available, using the Gibbs-SeaWater toolbox (TEOS-10) v3.05 from latitude and relative pressure measurements (calibration offset usually performed to balance current atmospheric pressure and acute sensor precision at a deployed depth).\n2016-07-18 04:26:24 UTC: passed compliance checks: cf (IOOS compliance checker version 2.2.0, IMOS plugin version 0.9.0)" ;
 data:
 
- DEPTH = _, 17.03845, 17.14089, 16.99426, 16.70422, 16.07214, 17.2725, 
+ DEPTH = _, _, -22.222, -11.1111, 16.70422, 16.07214, 17.2725,
     16.48994, 16.17254, 17.09642, 16.37582, 17.27692, 16.51809, 15.95106, 
     17.38825, 16.45131, 16.30933, 16.88206, 16.65124, 17.13555, 17.53368, 
     16.76055, 17.14427, 16.51801, 16.59242, 16.11634, 16.57016, 16.97042, 
@@ -157,7 +157,7 @@ data:
     16.83448, 16.92782, 17.33577, 16.5793, 16.7105, 17.22507, 16.30822, 
     16.94046, 16.82928, 17.03242, 16.83445, 16.91346, 16.89052 ;
 
- DEPTH_quality_control = 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+ DEPTH_quality_control = 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
@@ -189,7 +189,7 @@ data:
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
     1, 1, 1, 1, 1, 1, 1 ;
 
- TIME = 22229, 22230.7534722222, 22232.5069444445, 22234.2604166666, 
+ TIME = 0.0, 22230.7534722222, 22232.5069444445, 22234.2604166666,
     22236.0138888889, 22237.7673611111, 22239.5208333334, 22241.2743055555, 
     22243.0277777778, 22244.78125, 22246.5347222222, 22248.2881944445, 
     22250.0416666666, 22251.7951388889, 22253.5486111111, 22255.3020833334, 

--- a/cc_plugin_imos/tests/resources.py
+++ b/cc_plugin_imos/tests/resources.py
@@ -34,6 +34,7 @@ def static_files_testing():
         'data_var': get_filename('tests/data/imos_data_var.nc'),
         'bad_coords': get_filename('tests/data/imos_bad_coords.nc'),
         'new_data': get_filename('tests/data/imos_new_data.nc'),
+        'global_min_max': get_filename('tests/data/imos_global_min_max.nc'),
         'ghrsst_good_data': get_filename('tests/data/ghrsst_good_data.nc'),
         'ghrsst_bad_data': get_filename('tests/data/ghrsst_bad_data.nc'),
     }

--- a/cc_plugin_imos/tests/test_imos.py
+++ b/cc_plugin_imos/tests/test_imos.py
@@ -366,6 +366,7 @@ class TestIMOS1_3(unittest.TestCase):
         self.data_variable_dataset = self.load_dataset(self.static_files['data_var'])
         self.bad_coords_dataset = self.load_dataset(self.static_files['bad_coords'])
         self.new_dataset = self.load_dataset(self.static_files['new_data'])
+        self.global_min_max_dataset = self.load_dataset(self.static_files['global_min_max'])
 
     def test_check_mandatory_global_attributes(self):
         attributes = {'Conventions', 'project', 'naming_authority', 'data_centre', 'data_centre_email',
@@ -434,28 +435,26 @@ class TestIMOS1_3(unittest.TestCase):
             self.assertFalse(result.value)
 
     def test_check_geospatial_lat_min_max(self):
-        ret_val = self.imos.check_geospatial_lat_min_max(self.good_dataset)
-
+        ret_val = self.imos.check_geospatial_lat_min_max(self.global_min_max_dataset)
         for result in ret_val:
             self.assertTrue(result.value)
 
         ret_val = self.imos.check_geospatial_lat_min_max(self.bad_dataset)
-
         for result in ret_val:
             self.assertFalse(result.value)
 
         ret_val = self.imos.check_geospatial_lat_min_max(self.missing_dataset)
-
         self.assertEqual(len(ret_val), 0)
 
     def test_check_geospatial_lon_min_max(self):
-        ret_val = self.imos.check_geospatial_lon_min_max(self.good_dataset)
-
+        ret_val = self.imos.check_geospatial_lon_min_max(self.global_min_max_dataset)
         for result in ret_val:
-            self.assertTrue(result.value)
+            if 'check_maximum_value' in result.name:
+                self.assertFalse(result.value)
+            else:
+                self.assertTrue(result.value)
 
         ret_val = self.imos.check_geospatial_lon_min_max(self.bad_dataset)
-
         for result in ret_val:
             if 'check_attribute_type' in result.name:
                 self.assertTrue(result.value)
@@ -463,11 +462,10 @@ class TestIMOS1_3(unittest.TestCase):
                 self.assertFalse(result.value)
 
         ret_val = self.imos.check_geospatial_lon_min_max(self.missing_dataset)
-
         self.assertEqual(len(ret_val), 0)
 
     def test_check_geospatial_vertical_min_max(self):
-        ret_val = self.imos.check_geospatial_vertical_min_max(self.good_dataset)
+        ret_val = self.imos.check_geospatial_vertical_min_max(self.new_dataset)
         self.assertEqual(len(ret_val), 4)
         for result in ret_val:
             self.assertTrue(result.value)
@@ -489,13 +487,11 @@ class TestIMOS1_3(unittest.TestCase):
         self.assertEqual(len(ret_val), 0)
 
     def test_check_time_coverage(self):
-        ret_val = self.imos.check_time_coverage(self.good_dataset)
-
+        ret_val = self.imos.check_time_coverage(self.new_dataset)
         for result in ret_val:
             self.assertTrue(result.value)
 
         ret_val = self.imos.check_time_coverage(self.bad_dataset)
-
         for result in ret_val:
             self.assertFalse(result.value)
 


### PR DESCRIPTION
When checking variable values, we want to look at all values other than _FillValue. The latest versions of the netCDF4 package automatically mask out both fill values and any values outside the range specified by the variable's valid_min/max attributes. Instead of using this functionality, we now define a custom function to read in the raw variable values and mask out _only_ the fill values.