### PR TITLE
Allow global attribute Conventions to be space- or comma-separated

### DIFF
--- a/cc_plugin_imos/imos.py
+++ b/cc_plugin_imos/imos.py
@@ -39,7 +39,7 @@ class IMOSBaseCheck(BaseNCCheck):
     """
     register_checker = False
     _cc_spec = 'imos'
-    _cc_spec_version = 'base'
+    _cc_spec_version = None
     _cc_checker_version = __version__
     _cc_description = "Integrated Marine Observing System (IMOS) NetCDF Conventions"
     _cc_url = "http://imos.org.au/"
@@ -59,8 +59,9 @@ class IMOSBaseCheck(BaseNCCheck):
     OPERATOR_EMAIL = 8
 
     def __init__(self):
+        conventions = ['CF-1.6', 'IMOS-{version}'.format(version=self._cc_spec_version)]
         self.mandatory_global_attributes = {
-            'Conventions': '(.*,)?CF-1.6,IMOS-%s(,.*)?' % self._cc_spec_version,
+            'Conventions': [','.join(conventions), ' '.join(conventions)],
             'project': ['Integrated Marine Observing System (IMOS)'],
             'naming_authority': ['IMOS'],
             'date_created': is_timestamp,

--- a/cc_plugin_imos/tests/data/imos_new_data.cdl
+++ b/cc_plugin_imos/tests/data/imos_new_data.cdl
@@ -84,7 +84,7 @@ variables:
 		:file_version = "Level 1 - Quality Controlled Data" ;
 		:file_version_quality_control = "Quality controlled data have been through quality assurance procedures such as automated routines and sensor calibration or visual inspection and flag of obvious errors. The data are in physical units using standard SI metric units with calibration and other pre-processing routines applied, all time and location values are in absolute coordinates to comply with standards and datum. Data includes flags for each measurments to indicate the estimated quality of the measurement. Metadata exists for the data or for the higher level dataset that the data belongs to. This is the standard IMOS data level and is what should be made available to eMII and to the IMOS community." ;
 		:project = "Integrated Marine Observing System (IMOS)" ;
-		:Conventions = "CF-1.6,IMOS-1.4" ;
+		:Conventions = "CF-1.6 IMOS-1.4" ;
 		:standard_name_vocabulary = "NetCDF Climate and Forecast (CF) Metadata Convention Standard Name Table 27" ;
 		:title = "Ningaloo National Reference Station - Deployed 11/11/2010" ;
 		:institution = "ANMN-NRS" ;


### PR DESCRIPTION
For now we'll require this attribute to specify only CF-1.6 and IMOS conventions (in that order). If there is a need to add other conventions, we can make it more flexible in the future.