### PR TITLE
Update plugin to work with core checker v4.0

### DIFF
--- a/cc_plugin_imos/imos.py
+++ b/cc_plugin_imos/imos.py
@@ -44,6 +44,11 @@ class IMOSBaseCheck(BaseNCCheck):
     _cc_description = "Integrated Marine Observing System (IMOS) NetCDF Conventions"
     _cc_url = "http://imos.org.au/"
     _cc_authors = "Xiao Ming Fu, Marty Hidas"
+    _cc_display_headers = {
+        3: 'Required',
+        2: 'Recommended',
+        1: 'Suggested'
+    }
 
     CHECK_VARIABLE = 1
     CHECK_GLOBAL_ATTRIBUTE = 0

--- a/cc_plugin_imos/imos.py
+++ b/cc_plugin_imos/imos.py
@@ -127,7 +127,7 @@ class IMOSBaseCheck(BaseNCCheck):
             result (list): a list of Result objects
         """
         ret_val = []
-        result_name = ('globalattr', name, 'check_atttribute_type')
+        result_name = name
         reasoning = ["Attribute type is not string"]
         result = check_attribute_type((name,),
                                       basestring,
@@ -164,11 +164,11 @@ class IMOSBaseCheck(BaseNCCheck):
         for name in dataset.ncattrs():
             attribute_value = getattr(dataset, name)
             if isinstance(attribute_value, basestring):
-                result_name = ('globalattr', name, 'check_attribute_empty')
+                result_name = name
                 reasoning = None
                 if not attribute_value:
                     # empty global attribute
-                    reasoning = ["Attribute value is empty"]
+                    reasoning = ["Global attribute '{name}' is empty.".format(name=name)]
 
                 result = Result(BaseCheck.HIGH, reasoning is None, result_name, reasoning)
                 ret_val.append(result)
@@ -186,11 +186,11 @@ class IMOSBaseCheck(BaseNCCheck):
                 attribute_value = getattr(variable, attribute_name)
 
                 if isinstance(attribute_value, basestring):
-                    result_name = ('var', variable_name, attribute_name, 'check_attribute_empty')
+                    result_name = variable_name
                     reasoning = None
                     if not attribute_value:
                         # empty variable attribute
-                        reasoning = ["Attribute value is empty"]
+                        reasoning = ["Attribute '{name}' is empty.".format(name=attribute_name)]
 
                     result = Result(BaseCheck.HIGH, reasoning is None, result_name, reasoning)
                     ret_val.append(result)
@@ -204,13 +204,12 @@ class IMOSBaseCheck(BaseNCCheck):
         """
         ret_val = []
 
-        result_name = ('globalattr', 'geospatial_lat_min', 'check_attribute_type')
+        result_name = 'geospatial_lat_min'
         result = check_present(('LATITUDE',), dataset, self.CHECK_VARIABLE,
                                result_name,
                                BaseCheck.HIGH)
 
         if result.value:
-            result_name = ('globalattr', 'geospatial_lat_min', 'check_attribute_type')
             result = check_attribute_type(('geospatial_lat_min',),
                                           numeric_types,
                                           dataset,
@@ -224,7 +223,6 @@ class IMOSBaseCheck(BaseNCCheck):
 
             if result.value:
                 geospatial_lat_min = getattr(dataset, "geospatial_lat_min", None)
-                result_name = ('globalattr', 'geospatial_lat_min', 'check_minimum_value')
                 result = check_value(('LATITUDE',),
                                      geospatial_lat_min,
                                      self.OPERATOR_MIN,
@@ -234,7 +232,7 @@ class IMOSBaseCheck(BaseNCCheck):
                                      BaseCheck.HIGH)
                 ret_val.append(result)
 
-            result_name = ('globalattr', 'geospatial_lat_max', 'check_attribute_type')
+            result_name = 'geospatial_lat_max'
             result2 = check_attribute_type(('geospatial_lat_max',),
                                            numeric_types,
                                            dataset,
@@ -247,7 +245,6 @@ class IMOSBaseCheck(BaseNCCheck):
 
             if result2.value:
                 geospatial_lat_max = getattr(dataset, "geospatial_lat_max", None)
-                result_name = ('globalattr', 'geospatial_lat_max', 'check_maximum_value')
                 result = check_value(('LATITUDE',),
                                      geospatial_lat_max,
                                      self.OPERATOR_MAX,
@@ -266,13 +263,12 @@ class IMOSBaseCheck(BaseNCCheck):
         """
         ret_val = []
 
-        result_name = ('globalattr', 'geospatial_lon_min', 'check_attribute_type')
+        result_name = 'geospatial_lon_min'
         result = check_present(('LONGITUDE',), dataset, self.CHECK_VARIABLE,
                                result_name,
                                BaseCheck.HIGH)
 
         if result.value:
-            result_name = ('globalattr', 'geospatial_lon_min', 'check_attribute_type')
             result = check_attribute_type(('geospatial_lon_min',),
                                           numeric_types,
                                           dataset,
@@ -286,7 +282,6 @@ class IMOSBaseCheck(BaseNCCheck):
 
             if result.value:
                 geospatial_lon_min = getattr(dataset, "geospatial_lon_min", None)
-                result_name = ('globalattr', 'geospatial_lon_min', 'check_minimum_value')
                 result = check_value(('LONGITUDE',),
                                      geospatial_lon_min,
                                      self.OPERATOR_MIN,
@@ -296,7 +291,7 @@ class IMOSBaseCheck(BaseNCCheck):
                                      BaseCheck.HIGH)
                 ret_val.append(result)
 
-            result_name = ('globalattr', 'geospatial_lon_max', 'check_attribute_type')
+            result_name = 'geospatial_lon_max'
             result2 = check_attribute_type(('geospatial_lon_max',),
                                            numeric_types,
                                            dataset,
@@ -309,7 +304,6 @@ class IMOSBaseCheck(BaseNCCheck):
 
             if result2.value:
                 geospatial_lon_max = getattr(dataset, "geospatial_lon_max", None)
-                result_name = ('globalattr', 'geospatial_lon_max', 'check_maximum_value')
                 result = check_value(('LONGITUDE',),
                                      geospatial_lon_max,
                                      self.OPERATOR_MAX,
@@ -347,10 +341,11 @@ class IMOSBaseCheck(BaseNCCheck):
                 # no vertical information at all, nothing to report
                 return []
 
-            reasoning = ['Could not find vertical variable to check values of ''geospatial_vertical_min/max']
+            reasoning = ["Could not find vertical variable to check values"
+                         " of global attributes 'geospatial_vertical_min/max'."]
             result = Result(BaseCheck.MEDIUM,
                             False,
-                            ('globalattr', 'geospatial_vertical_extent', 'variable_present'),
+                            'geospatial_vertical_min/max',
                             reasoning)
             return [result]
 
@@ -358,7 +353,7 @@ class IMOSBaseCheck(BaseNCCheck):
         ret_val = []
         bad_attr = False
         for attr in ['geospatial_vertical_min', 'geospatial_vertical_max']:
-            result_name = ('globalattr', attr, 'type')
+            result_name = attr
             result = check_attribute_type((attr,),
                                           numeric_types,
                                           dataset,
@@ -398,14 +393,14 @@ class IMOSBaseCheck(BaseNCCheck):
         if not min_pass:
             reasoning = ["geospatial_vertical_min value (%s) did not match minimum value "
                          "of any vertical variable %s" % (vert_min, obs_mins)]
-        result_name = ('globalattr', 'geospatial_vertical_min', 'match_data')
+        result_name = 'geospatial_vertical_min'
         ret_val.append(Result(BaseCheck.HIGH, min_pass, result_name, reasoning))
 
         reasoning = []
         if not max_pass:
             reasoning = ["geospatial_vertical_max value (%s) did not match maximum value "
                          "of any vertical variable %s" % (vert_max, obs_maxs)]
-        result_name = ('globalattr', 'geospatial_vertical_max', 'match_data')
+        result_name = 'geospatial_vertical_max'
         ret_val.append(Result(BaseCheck.HIGH, max_pass, result_name, reasoning))
 
         return ret_val
@@ -416,7 +411,7 @@ class IMOSBaseCheck(BaseNCCheck):
         approximately match range in data and format 'YYYY-MM-DDThh:mm:ssZ'
         """
         ret_val = []
-        result_name = ('globalattr', 'time_coverage_start', 'check_date_format')
+        result_name = 'time_coverage_start'
 
         result = check_present(('TIME',), dataset, self.CHECK_VARIABLE,
                                result_name,
@@ -436,7 +431,6 @@ class IMOSBaseCheck(BaseNCCheck):
             results = self._check_str_type(dataset, 'time_coverage_start')
             result = results[0]
             if result.value:
-                result_name = ('globalattr', 'time_coverage_start', 'check_date_format')
                 result = check_value(('time_coverage_start',),
                                      date_attribute_format,
                                      self.OPERATOR_DATE_FORMAT,
@@ -451,14 +445,13 @@ class IMOSBaseCheck(BaseNCCheck):
                 time_coverage_start_string = getattr(dataset, "time_coverage_start", None)
                 time_coverage_start_datetime = datetime.strptime(time_coverage_start_string, date_attribute_format)
                 time_coverage_start = date2num(time_coverage_start_datetime, time_units, time_calendar)
-                result_name = ('globalattr', 'time_coverage_start', 'match_min_TIME')
                 reasoning = None
                 min_pass = np.isclose(time_min, time_coverage_start)
                 if not min_pass:
                     reasoning = [
                         "Attribute time_coverage_start ({attr}) doesn't match the minimum value of the "
-                        "TIME variable ({var})".format(attr=time_coverage_start_string,
-                                                       var=num2date(time_min, time_units, time_calendar))
+                        "TIME variable ({var}).".format(attr=time_coverage_start_string,
+                                                        var=num2date(time_min, time_units, time_calendar))
                     ]
 
                 result = Result(BaseCheck.HIGH, min_pass, result_name, reasoning)
@@ -467,7 +460,7 @@ class IMOSBaseCheck(BaseNCCheck):
             results = self._check_str_type(dataset, 'time_coverage_end')
             result = results[0]
             if result.value:
-                result_name = ('globalattr', 'time_coverage_end', 'check_date_format')
+                result_name = 'time_coverage_end'
                 result = check_value(('time_coverage_end',),
                                      date_attribute_format,
                                      self.OPERATOR_DATE_FORMAT,
@@ -482,14 +475,13 @@ class IMOSBaseCheck(BaseNCCheck):
                 time_coverage_end_string = getattr(dataset, "time_coverage_end", None)
                 time_coverage_end_datetime = datetime.strptime(time_coverage_end_string, date_attribute_format)
                 time_coverage_end = date2num(time_coverage_end_datetime, time_units, time_calendar)
-                result_name = ('globalattr', 'time_coverage_end', 'match_max_TIME')
                 reasoning = None
                 max_pass = np.isclose(time_max, time_coverage_end)
                 if not max_pass:
                     reasoning = [
                         "Attribute time_coverage_end ({attr}) doesn't match the maximum value of the "
-                        "TIME variable ({var})".format(attr=time_coverage_end_string,
-                                                       var=num2date(time_max, time_units, time_calendar))
+                        "TIME variable ({var}).".format(attr=time_coverage_end_string,
+                                                        var=num2date(time_max, time_units, time_calendar))
                     ]
 
                 result = Result(BaseCheck.HIGH, max_pass, result_name, reasoning)
@@ -503,8 +495,8 @@ class IMOSBaseCheck(BaseNCCheck):
         """
         ret_val = []
         for name, var in dataset.variables.iteritems():
-            result_name = ('var', name, 'long_name', 'check_atttribute_type')
-            reasoning = ["Attribute type is not string"]
+            result_name = name
+            reasoning = ["Attribute 'long_name' should be a string."]
 
             result = check_attribute_type((name, 'long_name',),
                                           basestring,
@@ -529,22 +521,21 @@ class IMOSBaseCheck(BaseNCCheck):
 
         ret_val = []
         for var in self._coordinate_variables:
-            result_name = ('var', 'coordinate_variable', var.name, 'check_variable_type')
+            result_name = var.name
             passed = True
             reasoning = None
             if not is_numeric(var.datatype):
-                reasoning = ["Variable type is not numeric"]
+                reasoning = ["Coordinate variable should be of numeric type."]
                 passed = False
 
             result = Result(BaseCheck.HIGH, passed, result_name, reasoning)
             ret_val.append(result)
 
-            result_name = ('var', var.name, 'check_monotonic')
             passed = is_monotonic(get_masked_array(var))
             reasoning = None
 
             if not passed:
-                reasoning = ["Variable values are not monotonic"]
+                reasoning = ["Coordinate variable values should be monotonic."]
 
             result = Result(BaseCheck.HIGH, passed, result_name, reasoning)
             ret_val.append(result)
@@ -555,10 +546,10 @@ class IMOSBaseCheck(BaseNCCheck):
                     or hasattr(var, 'positive'):
                 space_time_passed = True
 
-        result_name = ('var', 'coordinate_variable', 'space_time_coordinate_present')
+        result_name = 'Coordinate variables'
         reasoning = None
         if not space_time_passed:
-            reasoning = ["No space-time coordinate variable found"]
+            reasoning = ["File should contain at least one space-time coordinate variable (none found)."]
         result = Result(BaseCheck.HIGH, space_time_passed, result_name, reasoning)
         ret_val.append(result)
 
@@ -588,10 +579,10 @@ class IMOSBaseCheck(BaseNCCheck):
         if 'TIME' in dataset.variables:
             time_var = dataset.variables['TIME']
 
-            result = Result(BaseCheck.MEDIUM, True, name=('var', 'TIME'))
+            result = Result(BaseCheck.MEDIUM, True, name='TIME')
             if time_var.dtype != np.float64:
                 result.value = False
-                result.msgs = ["The TIME variable should be of type double (64-bit)"]
+                result.msgs = ["The TIME variable should be of type double (64-bit)."]
             ret_val.append(result)
 
             ret_val.extend(
@@ -630,10 +621,10 @@ class IMOSBaseCheck(BaseNCCheck):
         if 'LONGITUDE' in dataset.variables:
             longitude_var = dataset.variables['LONGITUDE']
 
-            result = Result(BaseCheck.MEDIUM, True, name=('var', 'LONGITUDE'))
+            result = Result(BaseCheck.MEDIUM, True, name='LONGITUDE')
             if longitude_var.dtype not in [np.float16, np.float32, np.float64, np.float128]:
                 result.value = False
-                result.msgs = ["The LONGITUDE variable should be of type double or float"]
+                result.msgs = ["The LONGITUDE variable should be of type double or float."]
             ret_val.append(result)
 
             ret_val.extend(
@@ -647,8 +638,10 @@ class IMOSBaseCheck(BaseNCCheck):
             valid_min = getattr(longitude_var, 'valid_min', None)
             valid_max = getattr(longitude_var, 'valid_max', None)
             if (valid_min, valid_max) not in valid_range_expected:
-                result = Result(BaseCheck.HIGH, False, name=('var', 'LONGITUDE', 'valid_min/max'))
-                result.msgs = ['(valid_min, valid_max) should be %s or %s' % valid_range_expected]
+                result = Result(BaseCheck.HIGH, False, name='LONGITUDE')
+                result.msgs = [
+                    'Attributes (valid_min, valid_max) should be %s or %s.' % valid_range_expected
+                ]
                 ret_val.append(result)
 
         return ret_val
@@ -676,10 +669,10 @@ class IMOSBaseCheck(BaseNCCheck):
         if 'LATITUDE' in dataset.variables:
             latitude_var = dataset.variables['LATITUDE']
 
-            result = Result(BaseCheck.MEDIUM, True, name=('var', 'LATITUDE'))
+            result = Result(BaseCheck.MEDIUM, True, name='LATITUDE')
             if latitude_var.dtype not in [np.float16, np.float32, np.float64, np.float128]:
                 result.value = False
-                result.msgs = ["The LATITUDE variable should be of type double or float"]
+                result.msgs = ["The LATITUDE variable should be of type double or float."]
             ret_val.append(result)
 
             ret_val.extend(
@@ -716,19 +709,18 @@ class IMOSBaseCheck(BaseNCCheck):
                 continue
 
             n_vertical_var += 1
-            result_name_std = ('var', name, 'standard_name', 'vertical')
-            result_name_pos = ('var', name, 'positive', 'vertical')
+            result_name = name
             if var_type == 'unknown':
                 # we only get this if var has axis='Z' but no valid
                 # standard_name or positive attribute
-                result = Result(BaseCheck.HIGH, False, result_name_std,
-                                ["Vertical coordinate variable (axis='Z') should have attribute"
-                                 " standard_name = 'depth' or 'height'"]
+                result = Result(BaseCheck.HIGH, False, result_name,
+                                ["Vertical coordinate variable (axis=\"Z\") should have attribute"
+                                 " 'standard_name' = \"depth\" or \"height\"."]
                                 )
                 ret_val.append(result)
-                result = Result(BaseCheck.HIGH, False, result_name_pos,
-                                ["Vertical coordinate variable (axis='Z') should have attribute"
-                                 " positive = 'up' or 'down'"]
+                result = Result(BaseCheck.HIGH, False, result_name,
+                                ["Vertical coordinate variable (axis=\"Z\") should have attribute"
+                                 " 'positive' = \"up\" or \"down\"."]
                                 )
                 ret_val.append(result)
 
@@ -742,19 +734,18 @@ class IMOSBaseCheck(BaseNCCheck):
                 valid = getattr(var, 'standard_name', '') == var_type
                 if not valid:
                     reasoning = ["Variable %s appears to be a vertical coordinate, should have attribute"
-                                 " standard_name = '%s'" % (name, var_type)]
-                result = Result(BaseCheck.HIGH, valid, result_name_std, reasoning)
+                                 " 'standard_name' = \"%s\"." % (name, var_type)]
+                result = Result(BaseCheck.HIGH, valid, result_name, reasoning)
                 ret_val.append(result)
 
                 reasoning = []
                 valid = getattr(var, 'positive', '') == expected_positive
                 if not valid:
                     reasoning = ["Variable %s appears to be a vertical coordinate, should have attribute"
-                                 " positive = '%s'" % (name, expected_positive)]
-                result = Result(BaseCheck.HIGH, valid, result_name_pos, reasoning)
+                                 " 'positive' = \"%s\"." % (name, expected_positive)]
+                result = Result(BaseCheck.HIGH, valid, result_name, reasoning)
                 ret_val.append(result)
 
-            result_name = ('var', name, 'reference_datum', 'type')
             result = check_attribute_type((name, 'reference_datum'),
                                           basestring,
                                           dataset,
@@ -763,7 +754,6 @@ class IMOSBaseCheck(BaseNCCheck):
                                           BaseCheck.HIGH)
             ret_val.append(result)
 
-            result_name = ('var', name, 'valid_min', 'present')
             result = check_present((name, 'valid_min'),
                                    dataset,
                                    self.CHECK_VARIABLE_ATTRIBUTE,
@@ -771,7 +761,6 @@ class IMOSBaseCheck(BaseNCCheck):
                                    BaseCheck.HIGH)
             ret_val.append(result)
 
-            result_name = ('var', name, 'valid_max', 'present')
             result = check_present((name, 'valid_max'),
                                    dataset,
                                    self.CHECK_VARIABLE_ATTRIBUTE,
@@ -779,14 +768,13 @@ class IMOSBaseCheck(BaseNCCheck):
                                    BaseCheck.HIGH)
             ret_val.append(result)
 
-            result_name = ('var', name, 'axis', 'vertical')
             axis = getattr(var, 'axis', '')
             if axis and axis == 'Z':
                 result = Result(BaseCheck.HIGH, True, result_name, None)
                 ret_val.append(result)
             else:
                 reasoning = ["Variable %s appears to be a vertical coordinate, should have attribute"
-                             " axis = 'Z'" % name]
+                             " 'axis' = \"Z\"." % name]
                 result = Result(BaseCheck.HIGH, False, result_name, reasoning)
                 if axis:
                     # axis attribute exists, incorrect value, so definitely report
@@ -795,7 +783,6 @@ class IMOSBaseCheck(BaseNCCheck):
                     # no axis attribute, which might be ok, review later
                     results_axis.append(result)
 
-            result_name = ('var', name, 'units', 'vertical')
             reasoning = ["Variable %s appears to be a vertical coordinate, should have"
                          " units of distance" % name]
             result = check_value((name, 'units',),
@@ -808,7 +795,6 @@ class IMOSBaseCheck(BaseNCCheck):
                                  reasoning)
             ret_val.append(result)
 
-            result_name = ('var', name, 'variable_type')
             reasoning = ["Variable %s should have type Double or Float" % name]
             result = check_attribute_type((name,),
                                           [np.float64, np.float, np.float32, np.float16, np.float128],
@@ -831,21 +817,18 @@ class IMOSBaseCheck(BaseNCCheck):
         """
 
         ret_val = []
-        reasoning = ["Attribute type is not same as variable type"]
         for name, var in dataset.variables.iteritems():
-            result_name = ('var', name, '_FillValue', 'check_attribute_type')
+            result_name = name
             result = check_attribute_type((name, '_FillValue',),
                                           var.datatype,
                                           dataset,
                                           self.CHECK_VARIABLE_ATTRIBUTE,
                                           result_name,
                                           BaseCheck.HIGH,
-                                          reasoning,
+                                          ["Attribute '_FillValue' should have same type as variable."],
                                           True)
             if result is not None:
                 ret_val.append(result)
-
-            result_name = ('var', name, 'valid_min', 'check_attribute_type')
 
             result = check_attribute_type((name, 'valid_min',),
                                           var.datatype,
@@ -853,19 +836,18 @@ class IMOSBaseCheck(BaseNCCheck):
                                           self.CHECK_VARIABLE_ATTRIBUTE,
                                           result_name,
                                           BaseCheck.HIGH,
-                                          reasoning,
+                                          ["Attribute 'valid_min' should have same type as variable."],
                                           True)
             if result is not None:
                 ret_val.append(result)
 
-            result_name = ('var', name, 'valid_max', 'check_attribute_type')
             result = check_attribute_type((name, 'valid_max',),
                                           var.datatype,
                                           dataset,
                                           self.CHECK_VARIABLE_ATTRIBUTE,
                                           result_name,
                                           BaseCheck.HIGH,
-                                          reasoning,
+                                          ["Attribute 'valid_max' should have same type as variable."],
                                           True)
             if result is not None:
                 ret_val.append(result)
@@ -876,9 +858,11 @@ class IMOSBaseCheck(BaseNCCheck):
         """
         Check that there's at least one data variable exists in the file
         """
-        result_name = ('var', 'data_variable_present')
+        result_name = 'data_variable_present'
         if not self._data_variables:
-            result = Result(BaseCheck.HIGH, False, result_name, ["No data variable exists"])
+            result = Result(BaseCheck.HIGH, False, result_name,
+                            ["File should contain at least one data variable (none found)."]
+                            )
         else:
             result = Result(BaseCheck.HIGH, True, result_name, None)
 
@@ -942,11 +926,14 @@ class IMOSBaseCheck(BaseNCCheck):
                 ancillary_variables = \
                     find_ancillary_variables_by_variable(dataset, data_variable)
                 if qc_variable in ancillary_variables:
-                    result_name = ('var', 'quality_variable', qc_variable.name, data_variable.name, 'check_dimension')
+                    result_name = qc_variable.name
                     if data_variable.dimensions == qc_variable.dimensions:
                         result = Result(BaseCheck.HIGH, True, result_name, None)
                     else:
-                        reasoning = ["Dimension is not same"]
+                        reasoning = [
+                            "Quality control variable should have the same dimensions as its "
+                            "associated data variable ({data}).".format(data=data_variable.name)
+                        ]
                         result = Result(BaseCheck.HIGH, False, result_name, reasoning)
 
                     ret_val.append(result)
@@ -961,12 +948,15 @@ class IMOSBaseCheck(BaseNCCheck):
         ret_val = []
 
         for quality_var in self._quality_control_variables:
-            result_name = ('var', 'quality_variable', quality_var.name, 'check_listed')
+            result_name = quality_var.name
 
             if quality_var in self._ancillary_variables:
                 result = Result(BaseCheck.MEDIUM, True, result_name, None)
             else:
-                reasoning = ["Quality variable is not listed in any data"" variable's ancillary_variables attribute"]
+                reasoning = [
+                    "Quality control variable is not listed in any data variable's "
+                    "'ancillary_variables' attribute."
+                ]
                 result = Result(BaseCheck.MEDIUM, False, result_name, reasoning)
 
             ret_val.append(result)
@@ -985,11 +975,13 @@ class IMOSBaseCheck(BaseNCCheck):
                     ds, variable)
                 if qc_variable in ancillary_variables:
                     value = getattr(variable, 'standard_name', '')
-                    result_name = ('var', 'quality_variable', qc_variable.name, variable.name, 'check_standard_name')
+                    result_name = qc_variable.name
                     if value:
                         value = value + ' ' + 'status_flag'
                         if getattr(qc_variable, 'standard_name', '') != value:
-                            reasoning = ["Standard name should be '%s'." % value]
+                            reasoning = [
+                                "Attribute 'standard_name' should be \"%s\"." % value
+                            ]
                             result = Result(BaseCheck.HIGH, False, result_name, reasoning)
                         else:
                             result = Result(BaseCheck.HIGH, True, result_name, None)
@@ -1001,12 +993,12 @@ class IMOSBaseCheck(BaseNCCheck):
 
     def check_geospatial_vertical_units(self, dataset):
         """
-        Check value of lgeospatial_vertical_units global attribute is valid CF depth
+        Check value of geospatial_vertical_units global attribute is valid CF depth
         unit, if exists
         """
         ret_val = []
-        result_name = ('var', 'geospatial_vertical_units', 'check_attributes')
-        reasoning = ["units is not a valid CF depth unit"]
+        result_name = 'geospatial_vertical_units'
+        reasoning = ["Global attribute 'geospatial_vertical_units' should be a valid CF depth unit."]
 
         result = check_value(('geospatial_vertical_units',),
                              'meter',
@@ -1084,8 +1076,8 @@ class IMOS1_3Check(IMOSBaseCheck):
         reasoning = None
         if acknowledgement is None:
             present = False
-            reasoning = ['Missing global attribute acknowledgement']
-        result_name = ('globalattr', 'acknowledgement', 'present')
+            reasoning = ['Missing global attribute acknowledgement.']
+        result_name = 'acknowledgement'
         result = Result(BaseCheck.HIGH, present, result_name, reasoning)
 
         ret_val.append(result)
@@ -1096,12 +1088,11 @@ class IMOS1_3Check(IMOSBaseCheck):
 
         # test whether old or new substrings match the attribute value
         passed = False
-        reasoning = ["acknowledgement string doesn't contain the required text"]
+        reasoning = ["acknowledgement string doesn't contain the required text."]
         if re.match(old_pattern, acknowledgement) or \
                 re.match(new_pattern, acknowledgement):
             passed = True
             reasoning = None
-        result_name = ('globalattr', 'acknowledgement', 'value')
         result = Result(BaseCheck.HIGH, passed, result_name, reasoning)
 
         ret_val.append(result)
@@ -1245,7 +1236,7 @@ class IMOS1_4Check(IMOSBaseCheck):
             if not hasattr(var, '_FillValue'):
                 continue
 
-            result = Result(BaseCheck.LOW, True, ('recommended', name, '_FillValue'))
+            result = Result(BaseCheck.LOW, True, name)
             if is_numeric(type(var._FillValue)) and np.isnan(var._FillValue):
                 result.value = False
                 result.msgs = [
@@ -1263,7 +1254,7 @@ class IMOS1_4Check(IMOSBaseCheck):
         """
         ret_val = []
         for var in self._coordinate_variables:
-            result = Result(BaseCheck.HIGH, True, ('var', var.name, 'no _FillValue'))
+            result = Result(BaseCheck.HIGH, True, var.name)
             if hasattr(var, '_FillValue'):
                 result.value = False
                 result.msgs = [

--- a/cc_plugin_imos/srs.py
+++ b/cc_plugin_imos/srs.py
@@ -117,7 +117,7 @@ class IMOSGHRSSTCheck(BaseNCCheck):
         if 'time' in dataset.variables:
             time_var = dataset.variables['time']
 
-            result = Result(BaseCheck.MEDIUM, True, name=('var', 'time'))
+            result = Result(BaseCheck.MEDIUM, True, name='time')
             if time_var.dtype != np.int32:
                 result.value = False
                 result.msgs = ["The time variable should be of type int"]
@@ -168,7 +168,7 @@ class IMOSGHRSSTCheck(BaseNCCheck):
         ret_val = []
 
         for mandatory_var in self.mandatory_variables:
-            result_name = ('var', mandatory_var)
+            result_name = mandatory_var
             if mandatory_var in dataset.variables.keys():
                 reasoning = None
             else:

--- a/cc_plugin_imos/srs.py
+++ b/cc_plugin_imos/srs.py
@@ -29,6 +29,11 @@ class IMOSGHRSSTCheck(BaseNCCheck):
     _cc_description = "Integrated Marine Observing System (IMOS) GHRSST checker"
     _cc_url = "http://imos.org.au/"
     _cc_authors = "Laurent Besnard"
+    _cc_display_headers = {
+        3: 'Required',
+        2: 'Recommended',
+        1: 'Suggested'
+    }
 
     def __init__(self):
         self.imos_1_3_check = IMOS1_3Check()

--- a/cc_plugin_imos/tests/data/imos_bad_coords.cdl
+++ b/cc_plugin_imos/tests/data/imos_bad_coords.cdl
@@ -14,12 +14,17 @@ variables:
 		DEPTH:positive = "up" ;
 		DEPTH:reference_datum = 123 ;
 		DEPTH:units = "dbar" ;
+		DEPTH:valid_min = 0 ;
+		DEPTH:valid_max = 1000 ;
 	float VERTICAL(time) ;
 		VERTICAL:positive = "up" ;
 		VERTICAL:_FillValue = -999. ;
+		VERTICAL:valid_min = 0 ;
+		VERTICAL:valid_max = 1000 ;
 	double HHH ;
 		HHH:axis = "Z" ;
 		HHH:reference_datum = "ground" ;
+		HHH:units = "m" ;
 	int LATITUDE ;
 		LATITUDE:standard_name = "" ;
 		LATITUDE:axis = "" ;

--- a/cc_plugin_imos/tests/data/imos_global_min_max.cdl
+++ b/cc_plugin_imos/tests/data/imos_global_min_max.cdl
@@ -31,8 +31,8 @@ variables:
 		:geospatial_lat_min = -30.0 ;
 		:geospatial_lat_max = 200.1 ;
 		:geospatial_lat_units = "degrees_north" ;
-		:geospatial_lon_min =  14.0 ;
-		:geospatial_lon_max = 113.94 ;
+		:geospatial_lon_min = 14.0 ;
+		:geospatial_lon_max = 2200.0;
 		:geospatial_lon_units = "degrees_east" ;
 data:
 

--- a/cc_plugin_imos/tests/test_srs.py
+++ b/cc_plugin_imos/tests/test_srs.py
@@ -135,13 +135,13 @@ class TestGHRSSTIMOSBase(unittest.TestCase):
     def test_check_data_variables(self):
         self.srs.setup(self.srs_good_dataset)
         ret_val = self.srs.check_data_variables(self.srs_good_dataset)
-        passed_var = [r.name[1] for r in ret_val if r.value]
+        passed_var = [r.name for r in ret_val if r.value]
         self.assertEqual(len(ret_val), 24)
         self.assertEqual(len(passed_var), 24)
 
         self.srs.setup(self.srs_bad_dataset)
         ret_val = self.srs.check_data_variables(self.srs_bad_dataset)
-        failed_var = [r.name[1] for r in ret_val if not r.value]
+        failed_var = [r.name for r in ret_val if not r.value]
         self.assertEqual(len(ret_val), 26)
         self.assertEqual(len(failed_var), 2)
         self.assertEqual(set(failed_var), {'random_var'})
@@ -150,7 +150,7 @@ class TestGHRSSTIMOSBase(unittest.TestCase):
                          'requires netCDF4 library version >= 4.3')
     def test_check_fill_value(self):
         ret_val = self.srs.check_fill_value(self.srs_bad_dataset)
-        failed_var = [r.name[1] for r in ret_val if not r.value]
+        failed_var = [r.name for r in ret_val if not r.value]
         self.assertEqual(failed_var, ['lon'])
 
     def test_check_mandatory_variables_exist(self):

--- a/cc_plugin_imos/util.py
+++ b/cc_plugin_imos/util.py
@@ -51,12 +51,12 @@ def is_timestamp(value):
 
     """
     if not isinstance(value, basestring):
-        return False, "should be a timestamp string"
+        return False, "should be a timestamp string."
 
     try:
         datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
     except ValueError:
-        return False, "is not in correct date/time format ('YYYY-MM-DDThh:mm:ssZ')"
+        return False, "is not in correct date/time format ('YYYY-MM-DDThh:mm:ssZ')."
 
     return True, None
 
@@ -74,7 +74,7 @@ def is_valid_email(email):
     if re.match(emailregex, email) is not None:
         return True, None
 
-    return False, "is not a valid email address"
+    return False, "is not a valid email address."
 
 
 def vertical_coordinate_type(dataset, variable):
@@ -251,25 +251,25 @@ def check_present(name, data, check_type, result_name, check_priority, reasoning
     reasoning_out = None
 
     if check_type == CHECK_GLOBAL_ATTRIBUTE:
-        result_name_out = result_name or ('globalattr', name[0], 'present')
+        result_name_out = result_name or name[0]
         if name[0] not in data.ncattrs():
-            reasoning_out = reasoning or ["Attribute %s not present" % name[0]]
+            reasoning_out = reasoning or ["Global attribute '%s' not present." % name[0]]
             passed = False
 
     if check_type == CHECK_VARIABLE or \
             check_type == CHECK_VARIABLE_ATTRIBUTE:
-        result_name_out = result_name or ('var', name[0], 'present')
+        result_name_out = result_name or name[0]
 
         variable = data.variables.get(name[0], None)
 
         if variable is None:
-            reasoning_out = reasoning or ['Variable %s not present' % name[0]]
+            reasoning_out = reasoning or ['Variable %s not present.' % name[0]]
             passed = False
 
         elif check_type == CHECK_VARIABLE_ATTRIBUTE:
-            result_name_out = result_name or ('var', name[0], name[1], 'present')
+            result_name_out = result_name or name[0]
             if name[1] not in variable.ncattrs():
-                reasoning_out = reasoning or ["Variable attribute %s:%s not present" % tuple(name)]
+                reasoning_out = reasoning or ["Variable attribute %s:%s not present." % tuple(name)]
                 passed = False
 
     result = Result(check_priority, passed, result_name_out, reasoning_out)
@@ -325,21 +325,21 @@ def check_value(name, value, operator, ds, check_type, result_name, check_priori
         if operator == OPERATOR_EQUAL:
             if retrieved_value != value:
                 passed = False
-                reasoning_out = reasoning or ["Attribute %s should be equal to '%s'" % (retrieved_name, str(value))]
+                reasoning_out = reasoning or ["Attribute %s should be equal to '%s'." % (retrieved_name, str(value))]
 
         if operator == OPERATOR_MIN:
             min_value = get_masked_array(variable).min()
 
             if not np.isclose(min_value, float(value)):
                 passed = False
-                reasoning_out = reasoning or ["Minimum value of %s (%f) does not match attributes (%f)" %
+                reasoning_out = reasoning or ["Minimum value of %s (%f) does not match attributes (%f)." %
                                               (retrieved_name, min_value, float(value))]
 
         if operator == OPERATOR_MAX:
             max_value = get_masked_array(variable).max()
             if not np.isclose(max_value, float(value)):
                 passed = False
-                reasoning_out = reasoning or ["Maximum value of %s (%f) does not match attributes (%f)" %
+                reasoning_out = reasoning or ["Maximum value of %s (%f) does not match attributes (%f)." %
                                               (retrieved_name, max_value, float(value))]
 
         if operator == OPERATOR_DATE_FORMAT:
@@ -347,29 +347,29 @@ def check_value(name, value, operator, ds, check_type, result_name, check_priori
                 datetime.datetime.strptime(retrieved_value, value)
             except ValueError:
                 passed = False
-                reasoning_out = reasoning or ["Attribute %s is not in correct date/time format (%s)" %
+                reasoning_out = reasoning or ["Attribute %s is not in correct date/time format (%s)." %
                                               (retrieved_name, value)]
 
         if operator == OPERATOR_SUB_STRING:
             if value not in retrieved_value:
                 passed = False
-                reasoning_out = reasoning or ["Attribute %s should contain the substring '%s'" %
+                reasoning_out = reasoning or ["Attribute %s should contain the substring '%s'." %
                                               (retrieved_name, value)]
 
         if operator == OPERATOR_CONVERTIBLE:
             if not units_convertible(retrieved_value, value):
                 passed = False
-                reasoning_out = reasoning or ["Units %s should be equivalent to %s" % (retrieved_name, value)]
+                reasoning_out = reasoning or ["Units %s should be equivalent to %s." % (retrieved_name, value)]
 
         if operator == OPERATOR_EMAIL:
             if not is_valid_email(retrieved_value)[0]:
                 passed = False
-                reasoning_out = reasoning or ["Attribute %s is not a valid email address" % retrieved_name]
+                reasoning_out = reasoning or ["Attribute %s is not a valid email address." % retrieved_name]
 
         if operator == OPERATOR_WITHIN:
             if retrieved_value not in value:
                 passed = False
-                reasoning_out = reasoning or ["Attribute %s is not in the expected range (%s)" %
+                reasoning_out = reasoning or ["Attribute %s is not in the expected range (%s)." %
                                               (retrieved_name, str(value))]
 
         result = Result(check_priority, passed, result_name, reasoning_out)
@@ -422,7 +422,7 @@ def check_attribute_type(name, expected_type, ds, check_type, result_name, check
 
         # check for array-valued attribute
         if isinstance(attribute_value, np.ndarray) and not allow_array:
-            reasoning = ["%s should be a single value of type %s" % (attribute_name, str(expected_type))]
+            reasoning = ["%s should be a single value of type %s." % (attribute_name, str(expected_type))]
             passed = False
 
         elif dtype is not None:
@@ -441,7 +441,7 @@ def check_attribute_type(name, expected_type, ds, check_type, result_name, check
 
         if not passed:
             if not reasoning:
-                reasoning = ["%s should have type %s" % (attribute_name, str(expected_type))]
+                reasoning = ["%s should have type %s." % (attribute_name, str(expected_type))]
             result = Result(check_priority, False, result_name, reasoning)
         else:
             result = Result(check_priority, True, result_name, None)
@@ -481,11 +481,11 @@ def check_attribute(name, expected, ds, priority=BaseCheck.HIGH, result_name=Non
     """
     if result_name is None:
         if isinstance(ds, Dataset):
-            result_name = ('globalattr', name)
-            message_name = "Attribute %s" % name
+            result_name = name
+            message_name = "Global attribute '{name}'".format(name=name)
         else:
-            result_name = ('var', ds.name, name)
-            message_name = "Attribute %s:%s" % (ds.name, name)
+            result_name = ds.name
+            message_name = "Attribute '{name}'".format(name=name)
     result = Result(priority, name=result_name, msgs=[])
     value = getattr(ds, name, None)
 
@@ -493,7 +493,7 @@ def check_attribute(name, expected, ds, priority=BaseCheck.HIGH, result_name=Non
         if optional:
             return None
         result.value = False
-        result.msgs.append("%s missing" % message_name)
+        result.msgs.append("%s missing." % message_name)
         return result
 
     if expected is None:
@@ -501,7 +501,7 @@ def check_attribute(name, expected, ds, priority=BaseCheck.HIGH, result_name=Non
         try:
             if not value.strip():
                 result.value = False
-                result.msgs.append("%s is empty or completely whitespace" % message_name)
+                result.msgs.append("%s is empty or completely whitespace." % message_name)
             else:
                 result.value = True
         # if not a string/has no strip method we should be OK
@@ -513,10 +513,13 @@ def check_attribute(name, expected, ds, priority=BaseCheck.HIGH, result_name=Non
             result.value = True
         else:
             result.value = False
-            if len(expected) == 1:
-                msg = "%s should be equal to %s" % (message_name, expected[0])
+            if len(expected) > 1:
+                msg = "{name} should be one of {exp}.".format(name=message_name, exp=expected)
+            elif isinstance(expected[0], basestring):
+                msg = "{name} should be set to \"{exp}\".".format(name=message_name, exp=expected[0])
             else:
-                msg = "%s should be one of %s" % (message_name, expected)
+                msg = "{name} should be set to {exp}.".format(name=message_name, exp=expected[0])
+
             result.msgs.append(msg)
 
     elif isinstance(expected, type):
@@ -525,25 +528,25 @@ def check_attribute(name, expected, ds, priority=BaseCheck.HIGH, result_name=Non
         else:
             result.value = False
             result.msgs.append(
-                '%s should be of %s' % (message_name, str(expected).strip('<>'))
+                '%s should be of %s.' % (message_name, str(expected).strip('<>'))
                 # str(expected) looks like "<type 'float'>"
             )
 
     elif hasattr(expected, '__call__'):
         result.value, message = expected(value)
         if not result.value and message:
-            result.msgs.append('%s %s' % (message_name, message))
+            result.msgs.append('%s %s.' % (message_name, message))
 
     elif isinstance(expected, basestring):
         if not isinstance(value, basestring):
             result.value = False
-            result.msgs.append('%s should be a string' % message_name)
+            result.msgs.append('%s should be a string.' % message_name)
         elif re.match(expected, value):
             result.value = True
         else:
             result.value = False
             result.msgs.append(
-                "%s does't match expected pattern '%s'" % (message_name, expected)
+                "%s does't match expected pattern \"%s\"." % (message_name, expected)
             )
 
     else:  # unsupported type in second element


### PR DESCRIPTION
* Add the new required class attribute `_cc_display_headers`, which provides names for the three priority levels used in printing the results.
* Update the `name` attribute of all `Result` objects to single strings, as this works better with the new output format.