### PR TITLE
Wave height is not a coordinate

### DIFF
--- a/cc_plugin_imos/tests/test_imos.py
+++ b/cc_plugin_imos/tests/test_imos.py
@@ -286,12 +286,15 @@ class TestUtils(unittest.TestCase):
         self.assertIsNone(util.vertical_coordinate_type(self.good_dataset, var))
         var = MockVariable('SIG_WAVE_HEIGHT', standard_name='sea_surface_wave_significant_height')
         self.assertIsNone(util.vertical_coordinate_type(self.good_dataset, var))
+        var = MockVariable('MAX_WAVE_HEIGHT', long_name='maximum wave height')
+        self.assertIsNone(util.vertical_coordinate_type(self.good_dataset, var))
 
         var = MockVariable('NOMINAL_DEPTH')
         self.assertEqual(util.vertical_coordinate_type(self.good_dataset, var), 'depth')
         var = MockVariable('HEIGHT_ABOVE_SENSOR')
         self.assertEqual(util.vertical_coordinate_type(self.good_dataset, var), 'height')
-        var = MockVariable('HEIGHT_SIG_WAVE_HEIGHT', standard_name='height')
+        var = MockVariable('HEIGHT_SIG_WAVE_HEIGHT', standard_name='height',
+                           long_name='height of sensor above water surface')
         self.assertEqual(util.vertical_coordinate_type(self.good_dataset, var), 'height')
 
         var = MockVariable('NONAME', standard_name='time')

--- a/cc_plugin_imos/util.py
+++ b/cc_plugin_imos/util.py
@@ -85,7 +85,7 @@ def vertical_coordinate_type(dataset, variable):
     A type is returned if the variable
       * is not listed as an ancillary variable; AND
       * does not have a standard_name equal to 'sea_floor_depth_below_sea_surface'
-        or containing the word 'wave' (wave height is not a coordinate);
+      * does not have standard_name or long_name containing the word 'wave' (wave height is not a coordinate);
     AND meets any of the conditions:
       * variable name includes 'depth' or 'height' (case-insensitive),
         but not 'quality_control'
@@ -100,9 +100,11 @@ def vertical_coordinate_type(dataset, variable):
     if variable in ancillary_variables:
         return None
 
-    # skip sea-floor depth and wave height
+    # skip sea-floor depth and wave height parameters
     standard_name = getattr(variable, 'standard_name', '')
-    if standard_name == 'sea_floor_depth_below_sea_surface' or 'wave' in standard_name:
+    if standard_name == 'sea_floor_depth_below_sea_surface' or 'wave' in str(standard_name):
+        return None
+    if 'wave' in str(getattr(variable, 'long_name', '')):
         return None
 
     name = getattr(variable, 'name', '')


### PR DESCRIPTION
We already had exceptions for wave height parameters so that they are not considered as vertical coordinate variables (and expected to have attributes `axis`, `positive`, etc...). This was done based on the _standard_name_ attribute containing the word "wave". However, we've recently received files containing valid wave parameters that only have a _long_name_  attribute, so adding that to the exceptions.