### PR TITLE
Update requirements for compatibility with core checker v4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 compliance-checker>=2.0.0
-netCDF4>=1.2.4,<1.4
+netCDF4>=1.2.4

--- a/setup.py
+++ b/setup.py
@@ -12,33 +12,34 @@ def readme():
 
 reqs = [line.strip() for line in open('requirements.txt')]
 
-setup(name                 = "cc_plugin_imos",
-      version              = __version__,
-      description          = "Compliance Checker plugin for IMOS conventions",
-      long_description     = readme(),
-      license              = 'GPLv3',
-      author               = "Xiao Ming Fu, Marty Hidas",
-      author_email         = "Marty.Hidas@utas.edu.au",
-      url                  = "https://github.com/aodn/data-services.git",
-      packages             = find_packages(),
-      install_requires     = reqs,
-      classifiers          = [
-          'Development Status :: 4 - Beta',
-          'Intended Audience :: Developers',
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-          'Operating System :: POSIX :: Linux',
-          'Programming Language :: Python',
-          'Topic :: Scientific/Engineering',
-      ],
-      entry_points         = {
-          'compliance_checker.suites': [
-              'imos13 = cc_plugin_imos.imos:IMOS1_3Check',
-              'imos14 = cc_plugin_imos.imos:IMOS1_4Check',
-              'ghrsst = cc_plugin_imos.srs:IMOSGHRSSTCheck'
-          ]
-      },
-      package_data         = {
-          'cc_plugin_imos': ['tests/data/*.cdl']
-      }
-     )
+setup(
+    name="cc_plugin_imos",
+    version=__version__,
+    description="Compliance Checker plugin for IMOS conventions",
+    long_description=readme(),
+    license='GPLv3',
+    author="Xiao Ming Fu, Marty Hidas",
+    author_email="Marty.Hidas@utas.edu.au",
+    url="https://github.com/aodn/cc-plugin-imos.git",
+    packages=find_packages(),
+    install_requires=reqs,
+    classifiers=[
+      'Development Status :: 4 - Beta',
+      'Intended Audience :: Developers',
+      'Intended Audience :: Science/Research',
+      'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+      'Operating System :: POSIX :: Linux',
+      'Programming Language :: Python',
+      'Topic :: Scientific/Engineering',
+    ],
+    entry_points={
+      'compliance_checker.suites': [
+          'imos13 = cc_plugin_imos.imos:IMOS1_3Check',
+          'imos14 = cc_plugin_imos.imos:IMOS1_4Check',
+          'ghrsst = cc_plugin_imos.srs:IMOSGHRSSTCheck'
+      ]
+    },
+    package_data={
+      'cc_plugin_imos': ['tests/data/*.cdl']
+    }
+)


### PR DESCRIPTION
(Plus a bit of cleaning up.)

Core checker now requires `netCDF4>=1.4.0`, so we need to remove a contradictory constraint from here. Let's see how we go...