### PR TITLE
GitHub Actions to test against python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.5', '3.6' ]
+        python-version: [ '3.5', '3.8' ]
     steps:
     - uses: actions/checkout@v2
     - name: Install libudunits2-dev and netcdf-bin

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 netCDF4<1.5.4;python_version=='3.5'
+cftime<1.5


### PR DESCRIPTION
Update the GitHub Actions config to test against the most relevant versions of python