### PR TITLE
Remove references to deprecated numpy types

### DIFF
--- a/cc_plugin_imos/imos.py
+++ b/cc_plugin_imos/imos.py
@@ -788,7 +788,7 @@ class IMOSBaseCheck(BaseNCCheck):
 
             reasoning = ["Variable %s should have type Double or Float." % name]
             result = check_attribute_type((name,),
-                                          [np.float64, np.float, np.float32, np.float16, np.float128],
+                                          [np.float64, float, np.float32, np.float16, np.float128],
                                           dataset,
                                           self.CHECK_VARIABLE,
                                           result_name,

--- a/cc_plugin_imos/tests/test_imos.py
+++ b/cc_plugin_imos/tests/test_imos.py
@@ -271,7 +271,7 @@ class TestUtils(unittest.TestCase):
                                                 util.CHECK_GLOBAL_ATTRIBUTE,
                                                 reasoning=['title not string'])
 
-        self._test_check_attribute_type_generic(('TEMP',), np.float32, np.int,
+        self._test_check_attribute_type_generic(('TEMP',), np.float32, int,
                                                 self.good_dataset,
                                                 util.CHECK_VARIABLE,
                                                 reasoning=['TEMP not float type'])

--- a/cc_plugin_imos/util.py
+++ b/cc_plugin_imos/util.py
@@ -26,8 +26,8 @@ OPERATOR_SUB_STRING = 6
 OPERATOR_CONVERTIBLE = 7
 OPERATOR_EMAIL = 8
 
-numeric_types = [np.float, np.double, np.float16, np.float32, np.float64, np.float128,
-                 np.int, np.byte, np.int8, np.int16, np.int32, np.int64]
+numeric_types = [float, np.double, np.float16, np.float32, np.float64, np.float128,
+                 int, np.byte, np.int8, np.int16, np.int32, np.int64]
 
 
 def is_numeric(variable_type):

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,1 @@
-compliance-checker<=4.1.1;python_version=='3.5'
-netCDF4<1.5.4;python_version=='3.5'
 cftime<1.5

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from __future__ import with_statement
 from __future__ import absolute_import
 from setuptools import find_packages, setup
 
-from cc_plugin_imos import __version__
 from io import open
 
 
@@ -30,13 +29,16 @@ setup(
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
     classifiers=[
-      'Development Status :: 4 - Beta',
-      'Intended Audience :: Developers',
-      'Intended Audience :: Science/Research',
-      'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-      'Operating System :: POSIX :: Linux',
-      'Programming Language :: Python',
-      'Topic :: Scientific/Engineering',
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Science/Research',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Topic :: Scientific/Engineering'
     ],
     entry_points={
       'compliance_checker.suites': [


### PR DESCRIPTION
Fixes #68
This will allow `numpy` to be upgraded to >=1.24