### PR TITLE
Required changes to run compliance-checker>=5.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
         pip install pytest-cov
         pip list
         pip show compliance-checker
+        pip install compliance-checker==5.4.2
+        pip list
+        pip show compliance-checker
     - name: Test with pytest
       run: |
         pytest --cov=./ --cov-report=xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.11' ]
     steps:
     - uses: actions/checkout@v2
     - name: Install libudunits2-dev and netcdf-bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,6 @@ jobs:
         pip install numpy
         pip install -r requirements.txt
         pip install pytest-cov
-        pip list
-        pip show compliance-checker
-        pip install compliance-checker==5.4.2
-        pip list
         pip show compliance-checker
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
         pip install numpy
         pip install -r requirements.txt
         pip install pytest-cov
+        pip list
+        pip show compliance-checker
     - name: Test with pytest
       run: |
         pytest --cov=./ --cov-report=xml

--- a/cc_plugin_imos/util.py
+++ b/cc_plugin_imos/util.py
@@ -10,7 +10,7 @@ from netCDF4 import Dataset
 
 from compliance_checker.base import BaseCheck
 from compliance_checker.base import Result
-from compliance_checker.cfutil import is_geophysical
+from compliance_checker.cf.util import is_geophysical
 from compliance_checker.cf.util import units_convertible
 import six
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,1 @@
 cftime<1.5
-compliance-checker==5.4.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 cftime<1.5
+compliance-checker==5.4.2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 
 INSTALL_REQUIRES = [
-    'compliance-checker',
+    'compliance-checker>=5.3',
     'netCDF4>=1.2.4'
 ]
 


### PR DESCRIPTION
Merge this when ready to use `compliance-checker version 5.4.2`. Or if this will impact legacy pipelines, we could use a v2 branch similar to what we did with aodntools.

We have to update `cc-plugin-imos` to Python >= 3.10 for the new `compliance-checker` to work. 

https://utas.atlassian.net/wiki/spaces/IMOS/pages/509542434/Issues